### PR TITLE
Updating the Sonatype credentials

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -16,7 +16,7 @@ jobs:
     uses: openrewrite/gh-automation/.github/workflows/publish-gradle.yml@main
     secrets:
       gradle_enterprise_access_key: ${{ secrets.GRADLE_ENTERPRISE_ACCESS_KEY }}
-      ossrh_username: ${{ secrets.OSSRH_USERNAME }}
-      ossrh_token: ${{ secrets.OSSRH_TOKEN }}
+      ossrh_username: ${{ secrets.OSSRH_USERNAME_1 }}
+      ossrh_token: ${{ secrets.OSSRH_TOKEN_1 }}
       ossrh_signing_key: ${{ secrets.OSSRH_SIGNING_KEY }}
       ossrh_signing_password: ${{ secrets.OSSRH_SIGNING_PASSWORD }}


### PR DESCRIPTION
Attempting to resolve the release issue by using the new user and associated token

We aren't updating the existing secrets to avoid destructive changes 